### PR TITLE
fix: bug not copying the full link to the clipboard in the dev menu

### DIFF
--- a/src/components/DeveloperDebugMenu/DeveloperDebugMenu.tsx
+++ b/src/components/DeveloperDebugMenu/DeveloperDebugMenu.tsx
@@ -193,7 +193,7 @@ const ConfigCreator: React.FC = () => {
           variant="muted"
           size="sm"
           onClick={() => {
-            navigator.clipboard.writeText(devConfigToQueryUrl(config));
+            navigator.clipboard.writeText(window.location.origin + "/?" + devConfigToQueryUrl(config));
             setShowCopiedMessage(true);
             setTimeout(() => {
               setShowCopiedMessage(false);


### PR DESCRIPTION
bug not copying the full link to the clipboard in the dev menu