### PR TITLE
chore: add tool for syncing core i18n locale files

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -5,13 +5,30 @@ When contributing to this repository, please first discuss the change you wish t
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 Pull Request Process
 
-    1. Find yourself an issue you want to work on, see if anybody is working on it, if not, then assign it to yourself
-    2. Fork the repo, create a branch for your issue
-    3. Make changes, commit and open a pull request into the [master](https://github.com/SeanCassiere/nv-reservation-cc-update/tree/master) branch
-    4. Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) while creating new commit
-    5. Request review from a contributor
-    6. If your pr was approved, rebase and squash your commits, then merge it.
-    7. Good job, you've just contributed!
+1. Find yourself an issue you want to work on, see if anybody is working on it, if not, then assign it to yourself
+2. Fork the repo, create a branch for your issue
+3. Make changes, commit and open a pull request into the [master](https://github.com/SeanCassiere/nv-reservation-cc-update/tree/master) branch
+4. Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) while creating new commit
+5. Request review from a contributor
+6. If your pr was approved, rebase and squash your commits, then merge it.
+7. Good job, you've just contributed!
 
-    Update the README.md with details of changes to the interface, this includes new environment variables (.env.example), exposed ports, useful file locations and container parameters. This will help new contributors to understand how to use the application.
-    You may merge your pull request after receiving an approval from Sean, or any other core contributor.
+You may merge your pull request after receiving an approval from Sean, or any other core contributor.
+
+## Documentation
+
+Update the [DOCUMENTATION](/DOCUMENTATION.md) if your contribution involves adding or changing configuration values.
+
+If the environment variables being used are changed or added onto, then please update the [.env.example](/.env.example) file with the required keys.
+
+This will help new contributors to understand how to both set up and use the application.
+
+## Localization
+
+If your change involves making changes to the existing verbiage or adding new keys, then please ensure you add them to the relevant localization files. You can find the localization files in the [/public/locales](/public/locales) directory.
+
+If you have added any new keys, you may run `npm run sync-i18n` to find the other core localization files that need to be update.
+
+## Code-style
+
+Please set up your code style with [prettier](https://prettier.io/). This project has a [.prettierrc](.prettierrc) file that can be used for code style.

--- a/locales-sync.config.js
+++ b/locales-sync.config.js
@@ -1,0 +1,19 @@
+const { resolve } = require("path");
+
+// these are the default values being using in ./src/i18n.ts
+const common = "common";
+const en = "en";
+const languagesCore = [common, en, "de", "fr", "es"];
+
+// derived to remove en and the common directory
+const secondaryLanguages = languagesCore.filter((l) => l !== en && l !== common);
+
+const srcLocalesPath = resolve(__dirname, "public", "locales");
+
+const config = {
+  primaryLanguage: "en",
+  secondaryLanguages,
+  localesFolder: srcLocalesPath,
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc",
     "serve:functions": "netlify dev --targetPort 4173",
     "serve:static-serve": "concurrently \"npm run preview\" \"npm run serve:functions\"",
-    "serve": "npm run build && npm run serve:static-serve"
+    "serve": "npm run build && npm run serve:static-serve",
+    "sync-i18n": "i18next-locales-sync -c ./locales-sync.config.js"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.2",
@@ -54,6 +55,7 @@
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.30.1",
+    "i18next-locales-sync": "^2.0.1",
     "postcss": "^8.4.16",
     "prettier": "2.7.1",
     "tailwindcss": "^3.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,7 +1787,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2666,6 +2666,15 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2747,7 +2756,7 @@ glob-parent@^6.0.1, glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3:
+glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2811,7 +2820,7 @@ globrex@^0.1.2:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
-graceful-fs@^4.2.4:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -2899,6 +2908,16 @@ i18next-http-backend@1.4.1:
   integrity sha512-s4Q9hK2jS29iyhniMP82z+yYY8riGTrWbnyvsSzi5TaF7Le4E7b5deTmtuaRuab9fdDcYXtcwdBgawZG+JCEjA==
   dependencies:
     cross-fetch "3.1.5"
+
+i18next-locales-sync@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-locales-sync/-/i18next-locales-sync-2.0.1.tgz#e0f219610c1a280f4ee0fa887bb0140b805e7a52"
+  integrity sha512-738OPrTSr3Tk4MyuhN5Gpb3KTNYyQ8GefY2JGgY1rHZVkUjASSukdejVnRxYnv4N5sJSeDzN2cdnXjGlnIM/Aw==
+  dependencies:
+    chalk "^4.1.2"
+    fs-extra "^10.0.0"
+    glob "^7.1.7"
+    yargs "^17.5.1"
 
 i18next@21.9.0:
   version "21.9.0"
@@ -3190,6 +3209,15 @@ json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.2.1"
@@ -4275,6 +4303,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
 update-browserslist-db@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
@@ -4430,7 +4463,7 @@ yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.5.1:
   version "17.5.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
   integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==


### PR DESCRIPTION
Use `npm run sync-i18n` to propagate new keys from the `en` locale to the other core languages (excluding common).