### PR TITLE
feat: change the developer menu shortcut to `Cmd + K`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -10,9 +10,9 @@ The information being requested from the client is based on the flow setup withi
 
 To create your own config and flow, you can use the built-in developer menu. You can access this menu using the following keyboard shortcut.
 
-Windows: `CTRL + SHIFT + K`
+Windows: `CTRL + K`
 
-Mac: `CMD + SHIFT + K`
+Mac: `CMD + K`
 
 ## URL params
 
@@ -58,6 +58,7 @@ Should you wish to manually create your own config string, you will need to crea
   "emailTemplateId": 7388,
   "flow": ["CreditCardForm"]
 }
+
 
 // Example Base64 --> eyJjbGllbnRJZCI6MTAxMywiZW1haWxUZW1wbGF0ZUlkIjo3Mzg4LCJmbG93IjpbIkRlZmF1bHQvQ3JlZGl0Q2FyZEZvcm0iXSwiZnJvbVJlbnRhbGwiOnRydWV9
 ```

--- a/src/app-entry.tsx
+++ b/src/app-entry.tsx
@@ -33,7 +33,7 @@ const App = () => {
   const handleCloseDeveloperDrawer = () => setOpenDevMenuLocal(false);
   React.useEffect(() => {
     function onKeyDown(evt: KeyboardEvent) {
-      if (evt.key === "k" && evt.shiftKey && (evt.metaKey || evt.ctrlKey)) {
+      if (evt.key === "k" && (evt.metaKey || evt.ctrlKey)) {
         if (shouldDevMenuBeLoaded.current === false) {
           shouldDevMenuBeLoaded.current = true;
         }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,7 +23,7 @@ export const APP_CONSTANTS = {
   SUCCESS_SUBMITTED_FORMS_WITH_RENTAL_CHARGES_SUMMARY: "SuccessSubmittedFormsWithRentalChargesSummary",
   SUCCESS_TEST: "test/test",
 
-  COLOR_SCHEME_DEFAULT_CLASS: "",
+  COLOR_SCHEME_DEFAULT_CLASS: "default", // this value should never be saved with the config
   COLOR_SCHEME_DARK_CLASS: "dark",
   COLOR_SCHEME_GREEN_CLASS: "green",
 


### PR DESCRIPTION
* Change the developer menu shortcut from `Cmd + Shift + K` to `Cmd + K`.
* Fix a bug causing the theme selector in the developer menu to crash when the value provided is `''`.